### PR TITLE
Бафы и фиксы режима

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -113,9 +113,12 @@
 - type: damageModifierSet
   id: Immortal
   coefficients:
-    Blunt: 0
-    Slash: 0
-    Piercing: 0
+    Blunt: 0.0
+    Slash: 0.0
+    Piercing: 0.0
+    Heat: 0.0
+    Shock: 0.0
+    Structural: 0.0
     Cold: 0.0
     Poison: 0.0
     Radiation: 0.0

--- a/Resources/Prototypes/Entities/Theta/ShipEvent/guns.yml
+++ b/Resources/Prototypes/Entities/Theta/ShipEvent/guns.yml
@@ -7,6 +7,7 @@
   components:
     - type: Gun
       fireRate: 4
+      projectileSpeed: 50
     - type: ItemSlots
       slots:
         gun_magazine:
@@ -58,10 +59,8 @@
     - type: ExplodeOnTrigger
     - type: Explosive
       explosionType: Default
-      maxIntensity: 10
-      totalIntensity: 15
+      totalIntensity: 5
       maxTileBreak: 1
-      tileBreakScale: 3
     - type: PointLight
       radius: 3.5
       color: orange

--- a/Resources/Prototypes/Entities/Theta/ShipEvent/human.yml
+++ b/Resources/Prototypes/Entities/Theta/ShipEvent/human.yml
@@ -16,6 +16,8 @@
       enabled: false
     - type: Damageable
       damageModifierSet: Immortal
+    - type: ExplosionResistance
+      damageCoefficient: 0.0
     - type: Barotrauma #no space damage.
       damage:
         types:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
1. Взрыв больше не дамажит шип-текст-куклу (потому что по какой-то причине взрыв игнорит дефолтные резисты)
2. Шип-тест-кукла неуязвима ко всему урону
3. Пуля пулемета летит быстрее в 2,5 раза
4. Демедж пулемета уменьшен. Теперь для ломания укреп стены нужно ~16 попадений (точных или не точных)