### PR TITLE
Два маленьких изменения

### DIFF
--- a/Content.Client/Theta/ShipEvent/Console/CannonConsoleWindow.xaml.cs
+++ b/Content.Client/Theta/ShipEvent/Console/CannonConsoleWindow.xaml.cs
@@ -16,8 +16,6 @@ public sealed partial class CannonConsoleWindow : FancyWindow,
 {
     private List<CannonInformationInterfaceState> _controlledCannons = new();
 
-    private Dictionary<EntityUid, CannonAmmoStatus> _ammoStatuses = new();
-
     public CannonConsoleWindow()
     {
         RobustXamlLoader.Load(this);
@@ -39,12 +37,8 @@ public sealed partial class CannonConsoleWindow : FancyWindow,
     {
         foreach (var cannonInformation in _controlledCannons)
         {
-            if (!_ammoStatuses.TryGetValue(cannonInformation.Uid, out var status))
-            {
-                status = new CannonAmmoStatus();
-                _ammoStatuses[cannonInformation.Uid] = status;
-                AmmoStatusContents.AddChild(status);
-            }
+            var status = new CannonAmmoStatus();
+            AmmoStatusContents.AddChild(status);
 
             var hasMagazine = cannonInformation is { Ammo: 0, Capacity: 0 };
             status.Update(!hasMagazine, cannonInformation.Ammo, cannonInformation.Capacity);

--- a/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/shotgun.yml
+++ b/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/shotgun.yml
@@ -89,6 +89,8 @@
     damage:
       types:
         Piercing: 100
+  - type: TimedDespawn
+    lifetime: 4
 
 - type: entity
   id: MagazineShotgunIncendiaryShipEvent


### PR DESCRIPTION
<!--
Хороший гайд из другого репозитория: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md

Описание:
Опишите изменения данного ПР-а. Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords

Почему и что этот ПР улучшит:
Опишите причину для изменений. Этот пункт особенно важен для описания изменений баланса, новых механик.

Чейнджлог:
Для чейнджлога существует 4 тэга: add, remove, tweak, fix. 
Вы можете указать своё имя после символа :cl: (вместо Theta Station)
-->



## Описание PR
- У сломанных или отцепившихся пушек больше не показывается боезапас
- Дробовичные патроны имеют уменьшенное время жизни. Было 10 сек, стало 4 сек (если это конечно секунды, а не какая-то хуйня в клиентских секундах или в клиентских фрейм-секундах)



**Скриншоты**

## Почему и что этот ПР улучшит
Пусть еще меньше будет лагать из-за них
