### PR TITLE
Фикс лобби

### DIFF
--- a/Content.Server/Theta/DebrisGeneration/Generators/AsteroidGenerator.cs
+++ b/Content.Server/Theta/DebrisGeneration/Generators/AsteroidGenerator.cs
@@ -45,14 +45,21 @@ public sealed class AsteroidGenerator : Generator
         var gridUid = gridComp.Owner;
 
         List<(Vector2i, Tile)> tiles = new();
+        List<(EntityCoordinates, string)> ents = new();
 
         foreach (var pos in tileSet)
         {
-            var coords = new EntityCoordinates(gridUid, pos);
-            gridComp.SetTile(coords, new Tile(tileDefMan[FloorId].TileId));
+            tiles.Add((pos, new Tile(tileDefMan[FloorId].TileId)));
             if (sys.Rand.Prob(Erosion))
                 continue;
-            sys.EntMan.SpawnEntity(WallPrototypeId, coords);
+            ents.Add((new EntityCoordinates(gridUid, pos), WallPrototypeId));
+        }
+        
+        gridComp.SetTiles(tiles);
+        foreach ((EntityCoordinates coords, string protId) in ents)
+        {
+            var ent = sys.EntMan.SpawnEntity(protId, coords);
+            sys.FormSys.AttachToGridOrMap(ent);
         }
 
         return gridUid;

--- a/Resources/Maps/Theta/Shipevent/shipevent-lobby.yml
+++ b/Resources/Maps/Theta/Shipevent/shipevent-lobby.yml
@@ -4,6 +4,7 @@ meta:
 tilemap:
   0: Space
   12: FloorBar
+  58: FloorReinforced
   68: FloorSteel
   71: FloorSteelDirty
   81: FloorWhite
@@ -21,7 +22,7 @@ entities:
     - chunks:
         0,0:
           ind: 0,0
-          tiles: RwAAAEQAAABEAAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAABEAAAARAAAAF4AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAARAAAAEcAAABeAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAEQAAABEAAAAXgAAAF0AAABdAAAAXQAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABEAAAAXgAAAF4AAABeAAAAXgAAAF0AAABdAAAAXQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAARAAAAEQAAABEAAAARAAAAF4AAABeAAAAXgAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAEQAAABEAAAARAAAAEQAAABRAAAAUQAAAFEAAABeAAAAXQAAAAAAAAAAAAAAAAAAAF0AAAAAAAAAAAAAAEQAAABEAAAARAAAAEQAAABEAAAAXgAAAFEAAABRAAAAXgAAAF0AAAAAAAAAAAAAAAAAAABdAAAAXQAAAF0AAABeAAAAXgAAAF4AAABEAAAAXgAAAF4AAABeAAAAXgAAAF4AAABdAAAAXQAAAAAAAAAAAAAAXQAAAF4AAABeAAAAXgAAAAAAAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAABdAAAAXQAAAF0AAABdAAAAXQAAAF0AAABeAAAAXgAAAF4AAAAAAAAAXgAAAEQAAABEAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAXQAAAF4AAABEAAAARAAAAEQAAABEAAAARAAAAEQAAABEAAAARAAAAEQAAABEAAAARAAAAEQAAABEAAAAXgAAAF0AAABeAAAARAAAAEQAAABeAAAAXgAAAF4AAABeAAAARAAAAEQAAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABdAAAAXgAAAF4AAABeAAAAXgAAAAAAAAAAAAAAXgAAAEQAAABEAAAAXgAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF0AAABdAAAAXQAAAF0AAABdAAAAXQAAAF4AAABEAAAARAAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: RwAAAEQAAABEAAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAABEAAAARAAAAF4AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAARAAAAEcAAABeAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAEQAAABEAAAAXgAAAF0AAABdAAAAXQAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABEAAAAXgAAAF4AAABeAAAAXgAAAF0AAABdAAAAXQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAARAAAAEQAAABEAAAARAAAAF4AAABeAAAAXgAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAEQAAABEAAAARAAAAEQAAABRAAAAUQAAAFEAAABeAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAABEAAAARAAAAEQAAABEAAAAXgAAAFEAAABRAAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF4AAAA6AAAAXgAAAF4AAABeAAAAXgAAAF4AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAAABeAAAAOgAAADoAAABeAAAAXQAAAF0AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAAAAAAAAXgAAADoAAAA6AAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXQAAAF4AAABeAAAAXgAAAF4AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF0AAABdAAAAXQAAAF0AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         0,-1:
           ind: 0,-1
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAXQAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF4AAABeAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAEQAAABEAAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
@@ -33,16 +34,13 @@ entities:
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAAAAAAAAAAAAAAAAAABdAAAAXgAAAA==
         0,1:
           ind: 0,1
-          tiles: XgAAAF4AAABdAAAAAAAAAAAAAAAAAAAAXQAAAF0AAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXQAAAF0AAAAAAAAAAAAAAAAAAABdAAAAXgAAAEQAAABEAAAAXgAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF4AAABEAAAARAAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAXgAAAEQAAABEAAAAXgAAAAAAAAAAAAAAAAAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF4AAABEAAAARAAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAAAAAAAAAAAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAXgAAAEQAAABEAAAAXgAAAAAAAAAAAAAAAAAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAXQAAAF4AAABEAAAARAAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAXgAAAEQAAABEAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF4AAABEAAAARAAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAABeAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAXQAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: XgAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXgAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         -1,1:
           ind: -1,1
           tiles: AAAAAF0AAAAAAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAF0AAABeAAAAXgAAAF4AAABeAAAAXgAAAF0AAABdAAAAAAAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAAAAAABdAAAAXgAAAF4AAABeAAAAXgAAAF4AAAAAAAAAXQAAAAAAAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAABdAAAAXQAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAF0AAABdAAAAXgAAAF4AAABeAAAAXgAAAF4AAABeAAAAAAAAAF0AAABeAAAAXgAAAF4AAABEAAAAXgAAAAAAAABdAAAAAAAAAF4AAABeAAAAXgAAAF4AAABeAAAAXgAAAAAAAABdAAAAXQAAAF4AAABEAAAARAAAAF4AAAAAAAAAAAAAAAAAAABeAAAAXgAAAF4AAABeAAAAXgAAAF4AAAAAAAAAAAAAAF0AAABeAAAARAAAAEQAAABeAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXgAAAF4AAAAAAAAAAAAAAAAAAABdAAAAXgAAAEQAAABEAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAAAAAAAAAAAAAAAAAABdAAAAXQAAAF4AAABeAAAAXgAAAF4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAXQAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         -2,0:
           ind: -2,0
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-        1,0:
-          ind: 1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABeAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF0AAABdAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AAABeAAAAXgAAAF0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAARAAAAF4AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAF4AAABeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       type: MapGrid
     - type: Broadphase
     - angularDamping: 0.05
@@ -262,7 +260,8 @@ entities:
     - type: RadiationGridResistance
     - id: LobbyShipevent
       type: BecomesStation
-    - type: SpreaderGrid
+    - nextUpdate: 0
+      type: SpreaderGrid
   - uid: 762
     components:
     - type: MetaData
@@ -272,6 +271,13 @@ entities:
     - type: Broadphase
     - type: OccluderTree
     - type: LoadedMap
+- proto: AirCanister
+  entities:
+  - uid: 158
+    components:
+    - pos: 4.5,7.5
+      parent: 1
+      type: Transform
 - proto: Airlock
   entities:
   - uid: 324
@@ -303,114 +309,16 @@ entities:
       pos: -1.5,19.5
       parent: 1
       type: Transform
-- proto: AirlockExternalGlassShuttleEmergencyLocked
-  entities:
-  - uid: 644
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 11.5,25.5
-      parent: 1
-      type: Transform
-    - fixtures:
-        docking:
-          shape: !type:PhysShapeCircle
-            radius: 0.2
-            position: 0,-0.5
-          mask: []
-          layer: []
-          density: 1
-          hard: False
-          restitution: 0
-          friction: 0.4
-      type: Fixtures
-    - canCollide: False
-      type: Physics
-  - uid: 645
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 11.5,23.5
-      parent: 1
-      type: Transform
-    - fixtures:
-        docking:
-          shape: !type:PhysShapeCircle
-            radius: 0.2
-            position: 0,-0.5
-          mask: []
-          layer: []
-          density: 1
-          hard: False
-          restitution: 0
-          friction: 0.4
-      type: Fixtures
-    - canCollide: False
-      type: Physics
-  - uid: 648
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 11.5,17.5
-      parent: 1
-      type: Transform
-    - fixtures:
-        docking:
-          shape: !type:PhysShapeCircle
-            radius: 0.2
-            position: 0,-0.5
-          mask: []
-          layer: []
-          density: 1
-          hard: False
-          restitution: 0
-          friction: 0.4
-      type: Fixtures
-    - canCollide: False
-      type: Physics
-  - uid: 649
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 11.5,15.5
-      parent: 1
-      type: Transform
-    - fixtures:
-        docking:
-          shape: !type:PhysShapeCircle
-            radius: 0.2
-            position: 0,-0.5
-          mask: []
-          layer: []
-          density: 1
-          hard: False
-          restitution: 0
-          friction: 0.4
-      type: Fixtures
-    - canCollide: False
-      type: Physics
-  - uid: 661
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 15.5,8.5
-      parent: 1
-      type: Transform
-    - fixtures:
-        docking:
-          shape: !type:PhysShapeCircle
-            radius: 0.2
-            position: 0,-0.5
-          mask: []
-          layer: []
-          density: 1
-          hard: False
-          restitution: 0
-          friction: 0.4
-      type: Fixtures
-    - canCollide: False
-      type: Physics
 - proto: AirlockExternalLocked
   entities:
-  - uid: 651
+  - uid: 48
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 15.5,10.5
+    - pos: 3.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 165
+    components:
+    - pos: 3.5,11.5
       parent: 1
       type: Transform
 - proto: AirlockExternalShuttleLocked
@@ -433,8 +341,6 @@ entities:
           restitution: 0
           friction: 0.4
       type: Fixtures
-    - canCollide: False
-      type: Physics
 - proto: AirlockGlass
   entities:
   - uid: 33
@@ -445,16 +351,6 @@ entities:
   - uid: 76
     components:
     - pos: -4.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 717
-    components:
-    - pos: 3.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 718
-    components:
-    - pos: 5.5,11.5
       parent: 1
       type: Transform
 - proto: AirlockSecurityGlassLocked
@@ -584,6 +480,22 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 160
+    components:
+    - pos: 3.5,11.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 168
+    components:
+    - pos: 3.5,10.5
+      parent: 1
+      type: Transform
     - fixtures: {}
       type: Fixtures
   - uid: 222
@@ -1149,13 +1061,6 @@ entities:
       type: Transform
     - fixtures: {}
       type: Fixtures
-  - uid: 650
-    components:
-    - pos: 11.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 672
     components:
     - pos: 3.5,8.5
@@ -1168,234 +1073,6 @@ entities:
     - pos: 3.5,9.5
       parent: 1
       type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 674
-    components:
-    - pos: 3.5,10.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 675
-    components:
-    - pos: 3.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 676
-    components:
-    - pos: 3.5,12.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 677
-    components:
-    - pos: 4.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 678
-    components:
-    - pos: 5.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 679
-    components:
-    - pos: 6.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 680
-    components:
-    - pos: 7.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 681
-    components:
-    - pos: 8.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 682
-    components:
-    - pos: 9.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 683
-    components:
-    - pos: 10.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 684
-    components:
-    - pos: 10.5,12.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 685
-    components:
-    - pos: 10.5,13.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 686
-    components:
-    - pos: 10.5,14.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 687
-    components:
-    - pos: 10.5,15.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 688
-    components:
-    - pos: 10.5,16.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 689
-    components:
-    - pos: 10.5,17.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 690
-    components:
-    - pos: 10.5,18.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 691
-    components:
-    - pos: 10.5,19.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 692
-    components:
-    - pos: 10.5,20.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 693
-    components:
-    - pos: 10.5,21.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 694
-    components:
-    - pos: 10.5,22.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 695
-    components:
-    - pos: 10.5,23.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 696
-    components:
-    - pos: 10.5,24.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 697
-    components:
-    - pos: 10.5,25.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 698
-    components:
-    - pos: 10.5,26.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 699
-    components:
-    - pos: 10.5,27.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 700
-    components:
-    - pos: 12.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 701
-    components:
-    - pos: 13.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 702
-    components:
-    - pos: 14.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 703
-    components:
-    - pos: 15.5,11.5
-      parent: 1
-      type: Transform
-    - fixtures: {}
-      type: Fixtures
-  - uid: 704
-    components:
-    - pos: 15.5,10.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
-  - uid: 705
-    components:
-    - pos: 15.5,9.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
     - fixtures: {}
       type: Fixtures
 - proto: CableApcStack
@@ -2310,6 +1987,31 @@ entities:
       type: Transform
 - proto: Catwalk
   entities:
+  - uid: 156
+    components:
+    - pos: 2.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 157
+    components:
+    - pos: 1.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 159
+    components:
+    - pos: 4.5,12.5
+      parent: 1
+      type: Transform
+  - uid: 167
+    components:
+    - pos: 1.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 299
+    components:
+    - pos: 3.5,12.5
+      parent: 1
+      type: Transform
   - uid: 513
     components:
     - pos: -14.5,19.5
@@ -2450,56 +2152,6 @@ entities:
     - pos: 1.5,-2.5
       parent: 1
       type: Transform
-  - uid: 738
-    components:
-    - pos: 15.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 747
-    components:
-    - pos: 16.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 748
-    components:
-    - pos: 17.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 749
-    components:
-    - pos: 17.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 750
-    components:
-    - pos: 14.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 751
-    components:
-    - pos: 13.5,7.5
-      parent: 1
-      type: Transform
-  - uid: 752
-    components:
-    - pos: 13.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 753
-    components:
-    - pos: 13.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 754
-    components:
-    - pos: 12.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 755
-    components:
-    - pos: 9.5,9.5
-      parent: 1
-      type: Transform
   - uid: 756
     components:
     - pos: 9.5,8.5
@@ -2549,48 +2201,6 @@ entities:
       pos: -2.5,11.5
       parent: 1
       type: Transform
-  - uid: 643
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 17.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 734
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 735
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 736
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 737
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 742
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 743
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,26.5
-      parent: 1
-      type: Transform
 - proto: ChairOfficeLight
   entities:
   - uid: 212
@@ -2624,14 +2234,6 @@ entities:
       pos: -9.5,21.5
       parent: 1
       type: Transform
-- proto: CigarGold
-  entities:
-  - uid: 728
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.255564,9.749941
-      parent: 1
-      type: Transform
 - proto: ClosetEmergencyFilledRandom
   entities:
   - uid: 578
@@ -2644,13 +2246,6 @@ entities:
   - uid: 361
     components:
     - pos: 1.5,7.5
-      parent: 1
-      type: Transform
-- proto: ClosetWallEmergencyFilledRandom
-  entities:
-  - uid: 746
-    components:
-    - pos: 10.5,28.5
       parent: 1
       type: Transform
 - proto: ClothingHandsGlovesColorYellow
@@ -2696,20 +2291,6 @@ entities:
           component: ClothingSpeedModifier
         title: null
       type: GroupExamine
-- proto: ComfyChair
-  entities:
-  - uid: 724
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 4.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 725
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 3.5,11.5
-      parent: 1
-      type: Transform
 - proto: ComputerFrame
   entities:
   - uid: 465
@@ -2735,13 +2316,6 @@ entities:
   - uid: 211
     components:
     - pos: -7.5,10.5
-      parent: 1
-      type: Transform
-- proto: ComputerTelevision
-  entities:
-  - uid: 723
-    components:
-    - pos: 3.5,12.5
       parent: 1
       type: Transform
 - proto: CrateEngineering
@@ -2787,11 +2361,6 @@ entities:
     - pos: -7.5,3.5
       parent: 1
       type: Transform
-  - uid: 567
-    components:
-    - pos: -7.5,3.5
-      parent: 1
-      type: Transform
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 334
@@ -2810,11 +2379,6 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 745
-    components:
-    - pos: 9.5,28.5
       parent: 1
       type: Transform
 - proto: filingCabinetDrawer
@@ -2912,176 +2476,15 @@ entities:
       pos: -8.5,8.5
       parent: 1
       type: Transform
-  - uid: 168
+  - uid: 163
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 3.5,8.5
+    - pos: 3.5,8.5
       parent: 1
       type: Transform
   - uid: 323
     components:
     - rot: 1.5707963267948966 rad
       pos: -7.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 569
-    components:
-    - pos: 11.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 581
-    components:
-    - pos: 8.5,17.5
-      parent: 1
-      type: Transform
-  - uid: 582
-    components:
-    - pos: 8.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 583
-    components:
-    - pos: 8.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 584
-    components:
-    - pos: 8.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 585
-    components:
-    - pos: 8.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 587
-    components:
-    - pos: 8.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 588
-    components:
-    - pos: 8.5,23.5
-      parent: 1
-      type: Transform
-  - uid: 589
-    components:
-    - pos: 8.5,26.5
-      parent: 1
-      type: Transform
-  - uid: 590
-    components:
-    - pos: 8.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 591
-    components:
-    - pos: 8.5,25.5
-      parent: 1
-      type: Transform
-  - uid: 599
-    components:
-    - pos: 11.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 600
-    components:
-    - pos: 11.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 602
-    components:
-    - pos: 11.5,17.5
-      parent: 1
-      type: Transform
-  - uid: 603
-    components:
-    - pos: 11.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 604
-    components:
-    - pos: 11.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 605
-    components:
-    - pos: 11.5,23.5
-      parent: 1
-      type: Transform
-  - uid: 606
-    components:
-    - pos: 11.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 607
-    components:
-    - pos: 11.5,25.5
-      parent: 1
-      type: Transform
-  - uid: 608
-    components:
-    - pos: 11.5,26.5
-      parent: 1
-      type: Transform
-  - uid: 610
-    components:
-    - pos: 17.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 615
-    components:
-    - pos: 18.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 616
-    components:
-    - pos: 18.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 642
-    components:
-    - pos: 18.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 652
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,20.5
-      parent: 1
-      type: Transform
-  - uid: 653
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,20.5
-      parent: 1
-      type: Transform
-  - uid: 654
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 10.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 655
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 9.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 656
-    components:
-    - pos: 15.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 671
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 5.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 706
-    components:
-    - pos: 17.5,12.5
       parent: 1
       type: Transform
 - proto: FoodBoxDonkpocket
@@ -3116,11 +2519,6 @@ entities:
       parent: 1
       type: Transform
   - uid: 561
-    components:
-    - pos: -7.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 562
     components:
     - pos: -7.5,3.5
       parent: 1
@@ -3219,41 +2617,6 @@ entities:
       pos: -8.5,8.5
       parent: 1
       type: Transform
-  - uid: 155
-    components:
-    - pos: 8.5,17.5
-      parent: 1
-      type: Transform
-  - uid: 157
-    components:
-    - pos: 8.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 158
-    components:
-    - pos: 8.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 159
-    components:
-    - pos: 8.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 160
-    components:
-    - pos: 8.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 301
-    components:
-    - pos: 8.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 332
-    components:
-    - pos: 8.5,26.5
-      parent: 1
-      type: Transform
   - uid: 459
     components:
     - rot: 1.5707963267948966 rad
@@ -3278,76 +2641,6 @@ entities:
       pos: -8.5,22.5
       parent: 1
       type: Transform
-  - uid: 573
-    components:
-    - pos: 8.5,25.5
-      parent: 1
-      type: Transform
-  - uid: 575
-    components:
-    - pos: 8.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 576
-    components:
-    - pos: 8.5,23.5
-      parent: 1
-      type: Transform
-  - uid: 665
-    components:
-    - pos: 11.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 666
-    components:
-    - pos: 11.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 667
-    components:
-    - pos: 11.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 668
-    components:
-    - pos: 11.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 669
-    components:
-    - pos: 11.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 670
-    components:
-    - pos: 11.5,26.5
-      parent: 1
-      type: Transform
-  - uid: 707
-    components:
-    - pos: 17.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 708
-    components:
-    - pos: 18.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 709
-    components:
-    - pos: 18.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 710
-    components:
-    - pos: 18.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 711
-    components:
-    - pos: 17.5,10.5
-      parent: 1
-      type: Transform
 - proto: Gyroscope
   entities:
   - uid: 719
@@ -3367,13 +2660,6 @@ entities:
   - uid: 331
     components:
     - pos: -6.5,2.5
-      parent: 1
-      type: Transform
-- proto: Lighter
-  entities:
-  - uid: 729
-    components:
-    - pos: 4.739939,9.656191
       parent: 1
       type: Transform
 - proto: MachineFrame
@@ -3445,14 +2731,6 @@ entities:
     - pos: -0.5,18.5
       parent: 1
       type: Transform
-- proto: PosterContrabandAmbrosiaVulgaris
-  entities:
-  - uid: 727
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,10.5
-      parent: 1
-      type: Transform
 - proto: PosterContrabandPunchShit
   entities:
   - uid: 342
@@ -3465,13 +2743,6 @@ entities:
   - uid: 341
     components:
     - pos: -0.5,0.5
-      parent: 1
-      type: Transform
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 744
-    components:
-    - pos: 13.5,12.5
       parent: 1
       type: Transform
 - proto: PosterLegit12Gauge
@@ -3591,51 +2862,6 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 731
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 10.5,13.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 732
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 10.5,27.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 733
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 10.5,20.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 739
-    components:
-    - pos: 3.5,12.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 740
-    components:
-    - pos: 7.5,11.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 741
-    components:
-    - pos: 16.5,11.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
 - proto: Rack
   entities:
   - uid: 206
@@ -3732,111 +2958,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 579
-    components:
-    - pos: 8.5,25.5
-      parent: 1
-      type: Transform
-  - uid: 580
-    components:
-    - pos: 8.5,26.5
-      parent: 1
-      type: Transform
-  - uid: 586
-    components:
-    - pos: 8.5,17.5
-      parent: 1
-      type: Transform
-  - uid: 592
-    components:
-    - pos: 8.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 593
-    components:
-    - pos: 8.5,23.5
-      parent: 1
-      type: Transform
-  - uid: 594
-    components:
-    - pos: 8.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 595
-    components:
-    - pos: 8.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 596
-    components:
-    - pos: 8.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 597
-    components:
-    - pos: 8.5,15.5
-      parent: 1
-      type: Transform
-  - uid: 598
-    components:
-    - pos: 8.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 601
-    components:
-    - pos: 11.5,14.5
-      parent: 1
-      type: Transform
-  - uid: 646
-    components:
-    - pos: 11.5,26.5
-      parent: 1
-      type: Transform
-  - uid: 647
-    components:
-    - pos: 11.5,24.5
-      parent: 1
-      type: Transform
-  - uid: 662
-    components:
-    - pos: 11.5,16.5
-      parent: 1
-      type: Transform
-  - uid: 663
-    components:
-    - pos: 11.5,18.5
-      parent: 1
-      type: Transform
-  - uid: 664
-    components:
-    - pos: 11.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 712
-    components:
-    - pos: 17.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 713
-    components:
-    - pos: 18.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 714
-    components:
-    - pos: 18.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 715
-    components:
-    - pos: 18.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 716
-    components:
-    - pos: 17.5,12.5
       parent: 1
       type: Transform
 - proto: Screwdriver
@@ -4023,13 +3144,6 @@ entities:
       pos: 9.5,7.5
       parent: 1
       type: Transform
-- proto: SpaceCash100
-  entities:
-  - uid: 730
-    components:
-    - pos: 4.295623,9.386902
-      parent: 1
-      type: Transform
 - proto: SpawnMobCleanBot
   entities:
   - uid: 525
@@ -4046,9 +3160,9 @@ entities:
       type: Transform
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 557
+  - uid: 298
     components:
-    - pos: 1.5,1.5
+    - pos: 6.5,6.5
       parent: 1
       type: Transform
 - proto: Stool
@@ -4143,14 +3257,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,21.5
-      parent: 1
-      type: Transform
-- proto: TableWood
-  entities:
-  - uid: 726
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 4.5,9.5
       parent: 1
       type: Transform
 - proto: TeamCreationConsoleShipEvent
@@ -4349,11 +3455,6 @@ entities:
   - uid: 42
     components:
     - pos: -0.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 48
-    components:
-    - pos: 10.5,28.5
       parent: 1
       type: Transform
   - uid: 49
@@ -4624,44 +3725,29 @@ entities:
       pos: -3.5,9.5
       parent: 1
       type: Transform
-  - uid: 156
+  - uid: 155
     components:
-    - pos: 11.5,27.5
+    - pos: 4.5,11.5
       parent: 1
       type: Transform
   - uid: 161
     components:
-    - pos: 8.5,27.5
+    - pos: 2.5,9.5
       parent: 1
       type: Transform
   - uid: 162
     components:
-    - pos: 8.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 163
-    components:
-    - pos: 11.5,20.5
+    - pos: 5.5,9.5
       parent: 1
       type: Transform
   - uid: 164
     components:
-    - pos: 11.5,21.5
-      parent: 1
-      type: Transform
-  - uid: 165
-    components:
-    - pos: 8.5,19.5
+    - pos: 5.5,11.5
       parent: 1
       type: Transform
   - uid: 166
     components:
-    - pos: 8.5,20.5
-      parent: 1
-      type: Transform
-  - uid: 167
-    components:
-    - pos: 8.5,21.5
+    - pos: 2.5,10.5
       parent: 1
       type: Transform
   - uid: 277
@@ -4674,34 +3760,19 @@ entities:
     - pos: -5.5,1.5
       parent: 1
       type: Transform
-  - uid: 298
-    components:
-    - pos: 9.5,28.5
-      parent: 1
-      type: Transform
-  - uid: 299
-    components:
-    - pos: 8.5,28.5
-      parent: 1
-      type: Transform
   - uid: 300
     components:
-    - pos: 11.5,28.5
+    - pos: 5.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 301
+    components:
+    - pos: 2.5,11.5
       parent: 1
       type: Transform
   - uid: 321
     components:
     - pos: -2.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 574
-    components:
-    - pos: 11.5,19.5
-      parent: 1
-      type: Transform
-  - uid: 577
-    components:
-    - pos: 11.5,13.5
       parent: 1
       type: Transform
 - proto: WallShuttle
@@ -5021,176 +4092,6 @@ entities:
   - uid: 192
     components:
     - pos: 6.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 609
-    components:
-    - pos: 16.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 611
-    components:
-    - pos: 14.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 612
-    components:
-    - pos: 14.5,8.5
-      parent: 1
-      type: Transform
-  - uid: 613
-    components:
-    - pos: 16.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 614
-    components:
-    - pos: 16.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 617
-    components:
-    - pos: 14.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 618
-    components:
-    - pos: 13.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 619
-    components:
-    - pos: 12.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 620
-    components:
-    - pos: 10.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 621
-    components:
-    - pos: 8.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 622
-    components:
-    - pos: 11.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 623
-    components:
-    - pos: 12.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 624
-    components:
-    - pos: 8.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 625
-    components:
-    - pos: 7.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 626
-    components:
-    - pos: 6.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 627
-    components:
-    - pos: 5.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 628
-    components:
-    - pos: 5.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 629
-    components:
-    - pos: 2.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 630
-    components:
-    - pos: 2.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 631
-    components:
-    - pos: 2.5,11.5
-      parent: 1
-      type: Transform
-  - uid: 632
-    components:
-    - pos: 2.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 633
-    components:
-    - pos: 2.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 634
-    components:
-    - pos: 5.5,9.5
-      parent: 1
-      type: Transform
-  - uid: 635
-    components:
-    - pos: 5.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 636
-    components:
-    - pos: 6.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 637
-    components:
-    - pos: 7.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 638
-    components:
-    - pos: 15.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 639
-    components:
-    - pos: 14.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 640
-    components:
-    - pos: 4.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 641
-    components:
-    - pos: 3.5,13.5
-      parent: 1
-      type: Transform
-  - uid: 657
-    components:
-    - pos: 16.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 658
-    components:
-    - pos: 13.5,12.5
-      parent: 1
-      type: Transform
-  - uid: 659
-    components:
-    - pos: 9.5,10.5
-      parent: 1
-      type: Transform
-  - uid: 660
-    components:
-    - pos: 11.5,10.5
       parent: 1
       type: Transform
 - proto: WaterCooler

--- a/Resources/Prototypes/Maps/shipevent-lobby.yml
+++ b/Resources/Prototypes/Maps/shipevent-lobby.yml
@@ -1,11 +1,21 @@
+- type: entity
+  id: LobbyShipeventStation
+  parent:
+    - BaseStation
+    - BaseStationJobsSpawning
+    - BaseStationNanotrasen
+  noSpawn: true
+  components:
+    - type: Transform
+
 - type: gameMap
   id: LobbyShipevent
   mapName: 'Lobby-Shipevent'
-  mapPath: /Maps/Theta/Shipevent/lobby.yml
+  mapPath: /Maps/Theta/Shipevent/shipevent-lobby.yml
   minPlayers: 1
   stations:
     LobbyShipevent:
-      stationProto: NanotrasenCentralCommand
+      stationProto: LobbyShipeventStation
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Lobby'


### PR DESCRIPTION
фиксит краш сервера при попытке запуска игры на лобби + удаляет на ней кишку для шаттлов, т.к. эвак и прибытие теперь отключены
