### PR TITLE
Микро-нёрф коробки

### DIFF
--- a/Resources/Maps/Theta/Shipevent/Ships/shipevent-boxship.yml
+++ b/Resources/Maps/Theta/Shipevent/Ships/shipevent-boxship.yml
@@ -568,7 +568,7 @@ entities:
     - ranges:
       - 3.2989882105173156 rad: 2.7868015397347476 rad
       type: Cannon
-    - fireRate: 1
+    - fireRate: 0.5
       type: Gun
     - links:
       - 41


### PR DESCRIPTION
## Описание PR
уменьшает скорострельность пушки на коробке с 1 до стандартных 0.5

**Скриншоты**

## Почему и что этот ПР улучшит
ну типо баланс, теперь либо по всей карте бегать не причиняя никакого урона, либо бесстрашно идти в лоб, т.к. попадать сложнее

## Чеинжлог
:cl: m104
mod: Уменьшена скорострельность пушки на коробке

