### PR TITLE
Убираю название и номер ПРа из ченджлога

### DIFF
--- a/Tools/cl.py
+++ b/Tools/cl.py
@@ -55,7 +55,7 @@ print(f"Target commit: {commitSha}")
 pr = getPullRequestByCommit(r.get_commit(commitSha))
 if pr is None: raise RuntimeError("Target commit does not belong to any pull request.")
 
-message = f"{parsePullRequestDesc(pr.body)}"
+message = parsePullRequestDesc(pr.body)
 print(f"Changelog generated successfully.\n---\n{message}\n---")
 
 response = post(hookUrl, json={"content" : message})

--- a/Tools/cl.py
+++ b/Tools/cl.py
@@ -55,7 +55,7 @@ print(f"Target commit: {commitSha}")
 pr = getPullRequestByCommit(r.get_commit(commitSha))
 if pr is None: raise RuntimeError("Target commit does not belong to any pull request.")
 
-message = f"# {pr.title} (#{pr.number})\n{parsePullRequestDesc(pr.body)}"
+message = f"{parsePullRequestDesc(pr.body)}"
 print(f"Changelog generated successfully.\n---\n{message}\n---")
 
 response = post(hookUrl, json={"content" : message})


### PR DESCRIPTION
<!--
Хороший гайд из другого репозитория: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md

Описание:
Опишите изменения данного ПР-а. Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords

Почему и что этот ПР улучшит:
Опишите причину для изменений. Этот пункт особенно важен для описания изменений баланса, новых механик.

Чейнджлог:
Чейнджлог поддерживает следущие теги:
add/new - новый контент
del/delete - удаление контента
mod/modify/tweak - изменение контента (например баланс)
fix - исправление багов

Вы можете указать своё имя после символа :cl: (вместо Theta Station). В случае если в вашем ПРе используются чужие ассеты/код, то сюда же следует поместить имена других авторов.
-->



## Описание PR
Мне кажется, тайтл занимает очень много места и по факту дублирует то, что уже написано в ченджлоге, так что думаю не нужно:
ДО
![image](https://github.com/ThetaStation/ThetaStation/assets/26389417/4b7524de-cf8f-4470-89aa-021998f1170a)

После
![image](https://github.com/ThetaStation/ThetaStation/assets/26389417/0d9fd46d-24d3-4131-be34-f69f9cc59b6d)

(я кста не тестил)

**Скриншоты**

## Почему и что этот ПР улучшит

## Чеинжлог
:cl:
mod: Чеинджлог в дискорде лишился заголовка