### PR TITLE
Radar works when reconnecting

### DIFF
--- a/Content.Client/UserInterface/Systems/Radar/RadarUIController.cs
+++ b/Content.Client/UserInterface/Systems/Radar/RadarUIController.cs
@@ -78,7 +78,7 @@ public sealed class RadarUIController : UIController
             return;
         }
 
-        if (RadarGui != null)
+        if (RadarGui != null || UIManager.ActiveScreen == null)
             return;
 
         RadarGui = new();


### PR DESCRIPTION
<!--
Description: Describe changes in this PR. If there are issues that will be resolved by it - also put them here (to close them automatically use keywords https://help.github.com/en/articles/closing-issues-using-keywords).

What will this PR improve: Describe motivation for your changes. This point is especially important for balance changes/new mechanics.

Changelog: 
Changelog supports following tags:
add/new - new content
del/delete - content removal
mod/modify/tweak - content tweaks (ex: balances changes)
fix - bugfixes

You can put your name after :cl: (instead of ThetaStation). In case if your PR uses assets/code which is not yours, you should also add other authors here.
-->


## Description
fix https://github.com/ThetaStation/ThetaStation/issues/241

Там крч PlayerAttachedEvent срабатывает раньше OnScreenLoad. Так как экрана нет, то радар создавался, но не добавлялся на экран. В итоге когда уже надо, он уже был создан и ифка дропалась

**Screenshots**

## What will this PR improve

## Changelog
:cl: ThetaStation
fix: Radar works when reconnecting
