### PR TITLE
При переподключении имя больше не переопределяется

### DIFF
--- a/Content.Server/Ghost/Roles/Components/UsePlayerNameForEntityNameComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/UsePlayerNameForEntityNameComponent.cs
@@ -6,5 +6,5 @@
 [RegisterComponent]
 public sealed class UsePlayerNameForEntityNameComponent : Component
 {
-
+    public bool Applied = false;
 }

--- a/Content.Server/Ghost/Roles/UsePlayerNameForEntityNameSystem.cs
+++ b/Content.Server/Ghost/Roles/UsePlayerNameForEntityNameSystem.cs
@@ -12,7 +12,10 @@ public sealed class UsePlayerNameForEntityNameSystem : EntitySystem
 
     private void ChangeEntityName(EntityUid uid, UsePlayerNameForEntityNameComponent component, PlayerAttachedEvent args)
     {
+        if(component.Applied)
+            return;
         var metaDataComponent = EntityManager.GetComponent<MetaDataComponent>(args.Entity);
         metaDataComponent.EntityName = args.Player.Name;
+        component.Applied = true;
     }
 }


### PR DESCRIPTION
<!--
Description: Describe changes in this PR. If there are issues that will be resolved by it - also put them here (to close them automatically use keywords https://help.github.com/en/articles/closing-issues-using-keywords).

What will this PR improve: Describe motivation for your changes. This point is especially important for balance changes/new mechanics.

Changelog: 
Changelog supports following tags:
add/new - new content
del/delete - content removal
mod/modify/tweak - content tweaks (ex: balances changes)
fix - bugfixes

You can put your name after :cl: (instead of ThetaStation). In case if your PR uses assets/code which is not yours, you should also add other authors here.
-->


## Description
fix https://github.com/ThetaStation/ThetaStation/issues/251

Я хз как правильно пофиксить, поэтому сделал, чтобы компонента имени игрока выдавалась на куклу только 1 раз, когда клиент входит в куклу.

**Screenshots**

## What will this PR improve

## Changelog
:cl:
- fix: Fixes the team name being removed after reconnecting