### PR TITLE
Fix of weirdly placed explosions during ship collision

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -1,5 +1,6 @@
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Shuttles.Components;
+using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Dynamics;
@@ -10,6 +11,7 @@ namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
+    [Dependency] private readonly TransformSystem _formSys = default!;
     [Dependency] private readonly ExplosionSystem _expSys = default!;
     
     /// <summary>
@@ -42,17 +44,15 @@ public sealed partial class ShuttleSystem
 
         var otherXform = Transform(args.OtherEntity);
 
-        var ourPoint = ourXform.InvWorldMatrix.Transform(args.WorldPoint);
-        var otherPoint = otherXform.InvWorldMatrix.Transform(args.WorldPoint);
+        var ourPoint = _formSys.GetWorldMatrix(ourXform).Transform(args.WorldPoint);
+        var otherPoint = _formSys.GetWorldMatrix(otherXform).Transform(args.WorldPoint);
 
         var ourVelocity = _physics.GetLinearVelocity(uid, ourPoint, ourBody, ourXform);
         var otherVelocity = _physics.GetLinearVelocity(args.OtherEntity, otherPoint, otherBody, otherXform);
         var jungleDiff = (ourVelocity - otherVelocity).Length;
 
         if (jungleDiff < MinimumImpactVelocity)
-        {
             return;
-        }
 
         var coordinates = new EntityCoordinates(ourXform.MapUid.Value, args.WorldPoint);
         var volume = MathF.Min(10f, 1f * MathF.Pow(jungleDiff, 0.5f) - 5f);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -3,7 +3,6 @@ using Content.Server.Shuttles.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
-using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
 
@@ -19,7 +18,7 @@ public sealed partial class ShuttleSystem
     /// </summary>
     private const int MinimumImpactVelocity = 10;
     
-    private const double IntensityMultiplier = 0.01;
+    private const double IntensityMultiplier = 10E-7; //carefully picked by trial & error
 
     private readonly SoundCollectionSpecifier _shuttleImpactSound = new("ShuttleImpactSound");
 


### PR DESCRIPTION
## Description
not sure if this really works better, but I haven't found explosions inside asteroids/ships during the testing, unlike from the current variant

**Screenshots**

## What will this PR improve
ramming into other ships will become more predictable

## Changelog
:cl: m104
fix: Fixes (?) incorrectly placed explosions during ramming
