### PR TITLE
Will anything bad happen if we don't use powershell?

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -45,7 +45,6 @@ jobs:
       run: dotnet test --configuration Tools --no-build Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
 
     - name: Run Content.IntegrationTests
-      shell: pwsh
       run: |
         $env:DOTNET_gcServer=1
         dotnet test --configuration Tools --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0


### PR DESCRIPTION
## Description

Github Action Runner Images even of Linux have powershell on them, our self-hosted runner doesn't.

