### PR TITLE
Наконец пофиксил шейдер

### DIFF
--- a/Content.Client/Theta/ShipEvent/Systems/BoundsOverlay.cs
+++ b/Content.Client/Theta/ShipEvent/Systems/BoundsOverlay.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
+
 namespace Content.Client.Theta.ShipEvent.Systems;
 
 public sealed class BoundsOverlay : Overlay
@@ -52,6 +53,12 @@ public sealed class BoundsOverlay : Overlay
 
                 _boundsShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
                 _boundsShader.SetParameter("BRIGHTNESS", Math.Clamp(SecondsOutsideBounds / FadeInTime, 0, 1));
+                _boundsShader.SetParameter("DET_LEVELS", 4);
+                
+                //so much zeros because we actually need mat2, yet RT does not have an overload for them
+                _boundsShader.SetParameter("SCALE_MATRIX", new Matrix3(0, 8.0f, 5.5f, 0, -5.5f, 8.0f, 0, 0, 0));
+                
+                _boundsShader.SetParameter("BASE_COLOR", new Vector3(1, 0, 0));
 
                 args.WorldHandle.UseShader(_boundsShader);
                 args.WorldHandle.DrawRect(args.WorldBounds, Color.White);

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -71,6 +71,7 @@
   id: Stealth
   kind: source
   path: "/Textures/Shaders/stealth.swsl"
+  
 - type: shader
   id: BoundsOverlay
   kind: source

--- a/Resources/Textures/Theta/ShipEvent/Shaders/bounds_overlay.swsl
+++ b/Resources/Textures/Theta/ShipEvent/Shaders/bounds_overlay.swsl
@@ -1,8 +1,8 @@
 uniform sampler2D SCREEN_TEXTURE;
 uniform highp float BRIGHTNESS;
-uniform lowp int DET_LEVELS = 2;
-uniform highp mat2 SCALE_MATRIX = mat2(2.0, 1.2, -1.2, 2.0);
-uniform highp vec3 BASE_COLOR = vec3(1.0,0.0,0.0);
+uniform lowp int DET_LEVELS;
+uniform highp mat3 SCALE_MATRIX; //this should be mat2, read BoundsOverlay.cs comments
+uniform highp vec3 BASE_COLOR;
 
 highp float rand(highp vec2 n) { 
     return fract(sin(dot(n, vec2(12.9898, 4.1414))) * 43758.5453);
@@ -31,7 +31,8 @@ highp float fbm(highp vec2 uv, highp mat2 m){
 }
 
 void fragment() {
-    highp float f = fbm(UV, SCALE_MATRIX); //Fractional brownian motion warp overlay, based on https://www.shadertoy.com/view/tdG3Rd
-    for(int c = 0; c < DET_LEVELS; c++){f = fbm(UV + f, SCALE_MATRIX);}
+    highp mat2 scale_mat2 = mat2(SCALE_MATRIX[0][1], SCALE_MATRIX[0][2], SCALE_MATRIX[1][1], SCALE_MATRIX[1][2]);
+    highp float f = fbm(UV, scale_mat2); //Fractional brownian motion warp overlay, based on https://www.shadertoy.com/view/tdG3Rd
+    for(int c = 0; c < DET_LEVELS; c++){f = fbm(UV + f, scale_mat2);}
     COLOR.xyz = mix(texture(SCREEN_TEXTURE, UV).xyz, BASE_COLOR, f*BRIGHTNESS);
 }


### PR DESCRIPTION
## Description
старый опенгл не поддерживал дефолтные значения для юниформов
алсо сам шейдер тоже поменялся, хоть я вроде правильно пересобираю мат3 в 2, всё равно со старыми значениями выходит совсем другое, поэтому покрутил

**Screenshots**

## What will this PR improve
fixes #320 

## Changelog
:cl: m104
fix: Шейдер выхода за границы поля корректно работает в режиме совместимости
