### PR TITLE
Щит на стрелу + пара фиксов

### DIFF
--- a/Content.Client/Theta/ShipEvent/Systems/BoundsOverlay.cs
+++ b/Content.Client/Theta/ShipEvent/Systems/BoundsOverlay.cs
@@ -39,12 +39,12 @@ public sealed class BoundsOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
+        if (args.MapId != TargetMap)
+            return;
+        
         if (_entMan.TryGetComponent<TransformComponent>(_playerMan.LocalPlayer?.ControlledEntity, out var form))
         {
             SecondsOutsideBounds += (float) (DateTime.Now - LastTime).TotalSeconds;
-
-            if (form.MapID != TargetMap)
-                return;
 
             if (!Bounds.Contains(_formSys.GetWorldPosition(form)))
             {

--- a/Content.Client/Theta/ShipEvent/Systems/CircularShieldOverlay.cs
+++ b/Content.Client/Theta/ShipEvent/Systems/CircularShieldOverlay.cs
@@ -31,9 +31,9 @@ public sealed class CircularShieldOverlay : Overlay
         foreach ((var form, var shield, var fix) in 
                  entMan.EntityQuery<TransformComponent, CircularShieldComponent, FixturesComponent>())
         {
-            if (!shield.CanWork)
+            if (!shield.CanWork || form.MapID != args.MapId)
                 continue;
-            
+
             PolygonShape? shape = (PolygonShape?)fix.Fixtures.GetValueOrDefault(ShieldFixtureId)?.Shape ?? null;
             if (shape == null)
                 continue;

--- a/Content.Server/Theta/DebrisGeneration/DebrisGenerationSystem.cs
+++ b/Content.Server/Theta/DebrisGeneration/DebrisGenerationSystem.cs
@@ -126,7 +126,12 @@ public sealed class DebrisGenerationSystem : EntitySystem
         var result = false;
         for (int n = 0; n < tries; n++)
         {
-            mapPos = (Vector2i) Rand.NextVector2Box(bounds.Left, bounds.Bottom, bounds.Right, bounds.Top).Rounded();
+            mapPos = (Vector2i) Rand.NextVector2Box(
+                bounds.Left + gridComp.LocalAABB.Width, 
+                bounds.Bottom + gridComp.LocalAABB.Height, 
+                bounds.Right - gridComp.LocalAABB.Width, 
+                bounds.Top - gridComp.LocalAABB.Height
+                ).Rounded();
             if (!MapMan.FindGridsIntersecting(targetMap,
                     new Box2(mapPos - finalDistance, mapPos + finalDistance)).Any())
             {

--- a/Resources/Maps/Theta/Shipevent/Ships/shipevent-arrowhead.yml
+++ b/Resources/Maps/Theta/Shipevent/Ships/shipevent-arrowhead.yml
@@ -388,6 +388,20 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
+  - uid: 208
+    components:
+    - pos: 3.5,10.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 209
+    components:
+    - pos: 3.5,11.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
 - proto: CableApcStack
   entities:
   - uid: 46
@@ -638,18 +652,37 @@ entities:
       pos: 2.5,8.5
       parent: 1
       type: Transform
+- proto: CircularShieldBase
+  entities:
+  - uid: 86
+    components:
+    - pos: 3.5,11.5
+      parent: 1
+      type: Transform
+    - radius: 10
+      width: 1.5707963267948966 rad
+      angle: 1.5707963267948966 rad
+      type: CircularShield
+    - links:
+      - 85
+      type: DeviceLinkSink
+- proto: CircularShieldConsole
+  entities:
+  - uid: 85
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        86:
+        - CircularShieldConsoleSender: CircularShieldConsoleReceiver
+      type: DeviceLinkSource
 - proto: ComputerShuttleSyndieShipEvent
   entities:
   - uid: 77
     components:
     - pos: 3.5,9.5
-      parent: 1
-      type: Transform
-- proto: CrateFoodMRE
-  entities:
-  - uid: 86
-    components:
-    - pos: 0.5,6.5
       parent: 1
       type: Transform
 - proto: FlakAmmoClosetShipEvent
@@ -666,7 +699,7 @@ entities:
     - pos: 4.5,7.5
       parent: 1
       type: Transform
-    - supplyRate: 30000
+    - supplyRate: 60000
       type: PowerSupplier
 - proto: GravityGeneratorMini
   entities:


### PR DESCRIPTION
## Description
на стрелу для тестов добавлен щит, оверлей щитов и границ поля больше не рисуется если клиент на другом слое, кораблики больше не должны спавнится вне границ поля (надеюсь)

**Screenshots**

## What will this PR improve
closes #352

## Changelog
:cl: m104
add: На стрелу добавлен круговой щит
