### PR TITLE
Фикс проклятого рантайма, который убивает сервер

### DIFF
--- a/Content.Shared/Interaction/RotateToFaceSystem.cs
+++ b/Content.Shared/Interaction/RotateToFaceSystem.cs
@@ -78,14 +78,11 @@ namespace Content.Shared.Interaction
             return TryFaceAngle(user, diffAngle);
         }
 
-        public bool TryFaceAngle(EntityUid user, Angle diffAngle, TransformComponent? xform = null)
+        public bool TryFaceAngle(EntityUid user, Angle diffAngle)
         {
             if (_actionBlockerSystem.CanChangeDirection(user))
             {
-                if (!Resolve(user, ref xform))
-                    return false;
-
-                xform.WorldRotation = diffAngle;
+                _transform.SetWorldRotation(user, diffAngle);
                 return true;
             }
 
@@ -101,7 +98,7 @@ namespace Content.Shared.Interaction
                         // (Since the user being buckled to it holds it down with their weight.)
                         // This is logically equivalent to RotateWhileAnchored.
                         // Barstools and office chairs have independent wheels, while regular chairs don't.
-                        Transform(rotatable.Owner).WorldRotation = diffAngle;
+                        _transform.SetWorldRotation(suid.Value, diffAngle);
                         return true;
                     }
                 }

--- a/Content.Shared/Interaction/RotateToFaceSystem.cs
+++ b/Content.Shared/Interaction/RotateToFaceSystem.cs
@@ -78,11 +78,14 @@ namespace Content.Shared.Interaction
             return TryFaceAngle(user, diffAngle);
         }
 
-        public bool TryFaceAngle(EntityUid user, Angle diffAngle)
+        public bool TryFaceAngle(EntityUid user, Angle diffAngle, TransformComponent? xform = null)
         {
             if (_actionBlockerSystem.CanChangeDirection(user))
             {
-                _transform.SetWorldRotation(user, diffAngle);
+                if (!Resolve(user, ref xform))
+                    return false;
+
+                xform.WorldRotation = diffAngle;
                 return true;
             }
 
@@ -98,7 +101,7 @@ namespace Content.Shared.Interaction
                         // (Since the user being buckled to it holds it down with their weight.)
                         // This is logically equivalent to RotateWhileAnchored.
                         // Barstools and office chairs have independent wheels, while regular chairs don't.
-                        _transform.SetWorldRotation(suid.Value, diffAngle);
+                        Transform(rotatable.Owner).WorldRotation = diffAngle;
                         return true;
                     }
                 }

--- a/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/ballistic.yml
+++ b/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/ballistic.yml
@@ -4,17 +4,12 @@
 #base
 - type: entity
   id: ShipEventCannonBase
+  parent: BaseStructure
   suffix: SHIPEVENT
   abstract: true
   components:
-    - type: Transform
-      anchored: true
     - type: Anchorable
       delay: 7
-    - type: Clickable
-    - type: Physics
-      bodyType: Static
-    - type: Pullable
     - type: CombatMode
       combatToggleAction:
         enabled: false

--- a/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/ballistic.yml
+++ b/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/ballistic.yml
@@ -8,6 +8,12 @@
   suffix: SHIPEVENT
   abstract: true
   components:
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.35,-0.35,0.35,0.35"
     - type: Anchorable
       delay: 7
     - type: CombatMode

--- a/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/ballistic.yml
+++ b/Resources/Prototypes/Entities/Theta/ShipEvent/cannons/ballistic.yml
@@ -4,12 +4,17 @@
 #base
 - type: entity
   id: ShipEventCannonBase
-  parent: BaseStructure
   suffix: SHIPEVENT
   abstract: true
   components:
+    - type: Transform
+      anchored: true
     - type: Anchorable
       delay: 7
+    - type: Clickable
+    - type: Physics
+      bodyType: Static
+    - type: Pullable
     - type: CombatMode
       combatToggleAction:
         enabled: false


### PR DESCRIPTION
<!--
Description: Describe changes in this PR. If there are issues that will be resolved by it - also put them here (to close them automatically use keywords https://help.github.com/en/articles/closing-issues-using-keywords).

What will this PR improve: Describe motivation for your changes. This point is especially important for balance changes/new mechanics.

Changelog: 
Changelog supports following tags:
add/new - new content
del/delete - content removal
mod/modify/tweak - content tweaks (ex: balances changes)
fix/bugfix - bugfixes
Adding [link] to the tag will provide a link to the Pull Request with this changelog, for example
fix[link]: Fixed that one annoying bug everyone keeps talking about.

You can put your name after :cl: (instead of ThetaStation). In case if your PR uses assets/code which is not yours, you should also add other authors here.
-->


## Description

Какой-то из этих ПРов поломал че-то и при повороте пушек, они нахуй сервак крашат.
![image](https://github.com/ThetaStation/ThetaStation/assets/26389417/627c81d9-6085-4e0f-8cd1-4576907ca670)

Краш с таким текстом:
![image](https://github.com/ThetaStation/ThetaStation/assets/26389417/e597e32a-6df2-4562-a93b-74f5d6722007)

В этом ПРе я делаю сторону невидимого бокса короче так, чтобы он не выходил за край грида. Сторона тайла 1, а значит, значит со стороной 0,7, второй квадрат он никогда не выйдет за пределы первого

**Screenshots**

## What will this PR improve

## Changelog