### PR TITLE
Fix MIT Licensing

### DIFF
--- a/MIT_LICENSE.TXT
+++ b/MIT_LICENSE.TXT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2024 Space Wizards Federation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Official site with the [documentation](https://docs.spacestation14.io/) has a lo
 
 ## License
 All the code belonging to our team after unix timestamp `1668875136` is licensed under AGPL.
-All the repo's code before unix timestamp `1668875136` is licensed under MIT or any other license specified in LICENSE.TXT for the appropriate version's state.
+All the other code before unix timestamp is licensed under MIT (see MIT_LICENSE.TXT) or any other license specified in LICENSE.TXT for the appropriate version's state, or source from which it has been copied.
 
 Most of the assets are licensed under [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/), unless stated otherwise. Assets have their license and author written in metadata file.
 


### PR DESCRIPTION
## Description

The license must be present as the code under it is still present in repo (i.e. upstream code)
