### PR TITLE
Reordered components in queries

### DIFF
--- a/Content.Client/Theta/ShipEvent/CannonDebugOverlay.cs
+++ b/Content.Client/Theta/ShipEvent/CannonDebugOverlay.cs
@@ -34,7 +34,7 @@ public sealed class DebugOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        foreach ((TransformComponent form, CannonComponent cannon) in entMan.EntityQuery<TransformComponent, CannonComponent>(true))
+        foreach ((var cannon, var form) in entMan.EntityQuery<CannonComponent, TransformComponent>(true))
         {
             if (!form.ParentUid.IsValid())
                 continue;

--- a/Content.Client/Theta/ShipEvent/Systems/CircularShieldOverlay.cs
+++ b/Content.Client/Theta/ShipEvent/Systems/CircularShieldOverlay.cs
@@ -34,8 +34,8 @@ public sealed class CircularShieldOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        var query = _entMan.EntityQuery<TransformComponent, CircularShieldComponent>();
-        foreach ((var form, var shield) in query)
+        var query = _entMan.EntityQuery<CircularShieldComponent, TransformComponent>();
+        foreach ((var shield, var form) in query)
         {
             if (!shield.CanWork || form.MapID != args.MapId)
                 continue;

--- a/Content.Server/Theta/ShipEvent/Systems/HealGridSystem.cs
+++ b/Content.Server/Theta/ShipEvent/Systems/HealGridSystem.cs
@@ -48,10 +48,10 @@ public sealed class HealGridSystem : EntitySystem
     private List<(EntityUid, DamageableComponent)> GetDamageableOnGrid(EntityUid gridUid)
     {
         var entityUids = new List<(EntityUid, DamageableComponent)>();
-        var query = EntityManager.EntityQueryEnumerator<TransformComponent, DamageableComponent>();
-        while (query.MoveNext(out var uid, out var transform, out var damageable))
+        var query = EntityManager.EntityQueryEnumerator<DamageableComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var damageable, out var form))
         {
-            if (transform.GridUid != gridUid || damageable.TotalDamage == FixedPoint2.Zero)
+            if (form.GridUid != gridUid || damageable.TotalDamage == FixedPoint2.Zero)
                 continue;
             entityUids.Add((uid, damageable));
         }

--- a/Content.Server/Theta/ShipEvent/Systems/Modifiers/SpaceDeathModifier.cs
+++ b/Content.Server/Theta/ShipEvent/Systems/Modifiers/SpaceDeathModifier.cs
@@ -31,11 +31,11 @@ public partial class SpaceDeathModifier : ShipEventModifier
 
     public void OnUpdate()
     {
-        var enumerator = _entMan.EntityQueryEnumerator<TransformComponent, MobStateComponent>();
+        var enumerator = _entMan.EntityQueryEnumerator<MobStateComponent, TransformComponent>();
         //this is required since when player will die team system will try to delete his body,
         //modifying query and causing it to throw
         var enumeratorCopy = new List<(EntityUid, TransformComponent)>();
-        while (enumerator.MoveNext(out var uid, out var form, out var _))
+        while (enumerator.MoveNext(out var uid, out var _, out var form))
         {
             enumeratorCopy.Add((uid, form));
         }

--- a/Content.Server/Theta/ShipEvent/Systems/MovementAccelerationSystem.cs
+++ b/Content.Server/Theta/ShipEvent/Systems/MovementAccelerationSystem.cs
@@ -14,9 +14,9 @@ public sealed class MovementAccelerationSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<TransformComponent, PhysicsComponent, MovementAccelerationComponent>();
+        var query = EntityQueryEnumerator<MovementAccelerationComponent, PhysicsComponent, TransformComponent>();
 
-        while (query.MoveNext(out var uid, out var form, out var body, out var accel))
+        while (query.MoveNext(out var uid, out var accel, out var body, out var form))
         {
             if (body.LinearVelocity.Length() >= accel.MaxVelocity)
                 return;

--- a/Content.Server/Theta/ShipEvent/Systems/ShipPickupSystem.cs
+++ b/Content.Server/Theta/ShipEvent/Systems/ShipPickupSystem.cs
@@ -21,8 +21,8 @@ public sealed partial class ShipPickupSystem : EntitySystem
         if (args.User == null || !HasComp<ShuttleComponent>(args.User))
             return;
 
-        var beaconQuery = EntityQueryEnumerator<TransformComponent, ShipPickupBeaconComponent>();
-        while (beaconQuery.MoveNext(out var beaconUid, out var form, out var beacon))
+        var beaconQuery = EntityQueryEnumerator<ShipPickupBeaconComponent, TransformComponent>();
+        while (beaconQuery.MoveNext(out var beaconUid, out var beacon, out var form))
         {
             if (form.GridUid == args.User && pickup.TargetBeaconId == beacon.Id)
             {


### PR DESCRIPTION
## Description
as kanopus has pointed out query methods search for components in the same order their types are given, so when using query<transform, component> for i.e. it was first searching for all entities with a transform attached, and only then picked those with the other component

**Screenshots**

## What will this PR improve

## Changelog
:cl: M104
add: Небольшие оптимизации, спасибо kanopus / Minor optimizations, thanks kanopus
